### PR TITLE
Increment upper pin for sphinx to `<5.1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - sphinx >=3,<5
+    - sphinx >=3,<5.1
     - importlib_resources
   run_constrained:
     - myst-nb >=0.13,<0.18


### PR DESCRIPTION
There are incompatible changes in Sphinx 5.1.0 according to https://github.com/executablebooks/sphinx-jupyterbook-latex/issues/101 but Sphinx 5.0.1 is compatible.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
